### PR TITLE
ClientError message set to body if empty

### DIFF
--- a/lib/vonage/errors.rb
+++ b/lib/vonage/errors.rb
@@ -31,6 +31,7 @@ module Vonage
         end
 
       message = response.content_type.to_s.include?("json") ? set_message(response) : ""
+      message = response.body.to_s if message.empty?
 
       exception_class.new(message, http_response: response)
     end


### PR DESCRIPTION
Add response body as a fallback error message in case it's empty.

Should help debugging this https://autoraptor-zf.sentry.io/issues/6802908394/?project=4508722956206080&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d